### PR TITLE
Fixed some typos and catpitalization errors

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
     <div class="wrapper">
       <header>
         <h1>Drupal Boilerplate</h1>
-        <p>Boilerplate project for drupal development</p>
+        <p>Boilerplate project for <a href="http://drupal.org/">Drupal</a> development</p>
         <p class="view"><a href="https://github.com/Lullabot/drupal-boilerplate">View the Project on GitHub <small>Lullabot/drupal-boilerplate</small></a></p>
         <ul>
           <li><a href="https://github.com/Lullabot/drupal-boilerplate/zipball/master">Download <strong>ZIP File</strong></a></li>
@@ -27,14 +27,14 @@
       <section>
         <h3>Drupal Boilerplate.</h3>
 
-<p>Drupal boilerplate is not a module. Instead it just serves as a directory structure for starting a new drupal site. The idea behind Drupal boilerplate came from working on so many different sites which each follow their own development practice, directory structure, deployment guidelines, etc...</p>
+<p>Drupal boilerplate is not a module. Instead it just serves as a directory structure for starting a new Drupal site. The idea behind Drupal boilerplate came from working on so many different sites which each follow their own development practice, directory structure, deployment guidelines, etc...</p>
 
 <p>Drupal boilerplate tries to simplifies starting a new site by having the most common directory structures and files already included and set up.</p>
 
 <h3>Getting started</h3>
 
 <p>You can start by <a href="https://github.com/Lullabot/drupal-boilerplate/zipball/master">downloading</a>
-this project. Once you download it you will fine every folder contains a readme.md file
+this project. Once you download it you will find every folder contains a readme.md file
 in it. This readme.md file has been extensively documented to explain what belongs
 in that specific directory.</p>
 
@@ -46,7 +46,7 @@ read the readme inside the specific directory.</p>
 <a href="https://github.com/Lullabot/drupal-boilerplate/tree/master/docroot">docroot</a>
 
 <ul>
-<li>Where your drupal root should start.</li>
+<li>Where your Drupal root should start.</li>
 </ul>
 </li>
 <li>
@@ -69,8 +69,7 @@ to this directory for parsing by external tools.</li>
 <a href="https://github.com/Lullabot/drupal-boilerplate/tree/master/test">test</a>
 
 <ul>
-<li>A directory for external test. This is great for non drupal specific test
-such as selenium, qunit, casperjs.</li>
+<li>A directory for external test. This is great for tests that are not specific to Drupal, such as selenium, qunit, casperjs.</li>
 </ul>
 </li>
 <li>


### PR DESCRIPTION
Mostly capitalized Drupal, linked to d.o, etc. Not sure if `params.json` also needs to change, or if that's only used during initial page creation.
