### PR TITLE
Missing arguments for downsync

### DIFF
--- a/drush/commands/downsync.drush.inc
+++ b/drush/commands/downsync.drush.inc
@@ -44,9 +44,9 @@ function drush_downsync($source = NULL, $destination = NULL) {
   // Execute a drush sql-sync
   print dt('SQL Sync running... NOTE: if you do not have ssh passwordless logins setup, you may be asked for your password multiple times.');
 
-  drush_invoke('sql-sync', $source, $destination);
+  drush_invoke('sql-sync', array($source, $destination));
 
   // Rsync the files.
   print dt('Rsync-ing files...');
-  drush_invoke('rsync', $source .':%files', $destination .':%files');
+  drush_invoke('rsync', array($source .':%files', $destination .':%files'));
 }


### PR DESCRIPTION
drush_invoke expects the invoked command arguments to be passed as an array (at least for 5.x)

```
function drush_invoke($command, $arguments = array())
```

Current code of downsync causes a notice about a missing second argument for rsync and fails to sync files. I haven't noticed the same behavior for sql-sync, however this pull request amends both calls in downsync.
