### PR TITLE
Ignore aliases file with local settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 # Ignore configuration files that may contain sensitive information.
 docroot/sites/*/settings*.php
 *.local.php
+drush/aliases/aliases.drushrc.php
 
 # User Generated Content #
 ##########################


### PR DESCRIPTION
Ignore local aliases file that keeps @myproject.local - these are not shared with the team
